### PR TITLE
feat: New prop for supporting onWillShow and onWillHide props in iOS

### DIFF
--- a/packages/zeego/src/dropdown-menu/dropdown-menu.web.tsx
+++ b/packages/zeego/src/dropdown-menu/dropdown-menu.web.tsx
@@ -17,9 +17,9 @@ import React, { forwardRef } from 'react'
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 
-const Root = ({ children, onOpenChange }: MenuRootProps) => {
+const Root = ({ children, onOpenChange, onExpandedChange }: MenuRootProps) => {
   return (
-    <DropdownMenu.Root onOpenChange={onOpenChange}>
+    <DropdownMenu.Root onOpenChange={onOpenChange} onExpandedChange={onExpandedChange}>
       {children}
     </DropdownMenu.Root>
   )

--- a/packages/zeego/src/menu/create-ios-menu/index.ios.tsx
+++ b/packages/zeego/src/menu/create-ios-menu/index.ios.tsx
@@ -430,6 +430,7 @@ If you want to use a custom component as your <Content />, you can use the menui
       (() => {
         props.onExpandedChange?.(false)
       })
+
     return (
       <Component
         onPressMenuItem={({ nativeEvent }) => {

--- a/packages/zeego/src/menu/create-ios-menu/index.ios.tsx
+++ b/packages/zeego/src/menu/create-ios-menu/index.ios.tsx
@@ -420,7 +420,16 @@ If you want to use a custom component as your <Content />, you can use the menui
       (() => {
         props.onOpenChange?.(true)
       })
-
+    const onMenuWillShow =
+      props.onExpandedChange && 
+      (() => {
+        props.onExpandedChange?.(true)
+      })
+    const onMenuWillHide = 
+      props.onExpandedChange &&
+      (() => {
+        props.onExpandedChange?.(false)
+      })
     return (
       <Component
         onPressMenuItem={({ nativeEvent }) => {
@@ -470,6 +479,8 @@ If you want to use a custom component as your <Content />, you can use the menui
         }
         onMenuDidHide={onMenuDidHide}
         onMenuDidShow={onMenuDidShow}
+        onMenuWillHide={onMenuWillHide}
+        onMenuWillShow={onMenuWillShow}
       >
         {trigger.targetChildren?.[0]}
       </Component>

--- a/packages/zeego/src/menu/types.ts
+++ b/packages/zeego/src/menu/types.ts
@@ -10,6 +10,9 @@ export type MenuRootProps = {
   children: React.ReactNode
   style?: ViewStyle
   onOpenChange?: (isOpen: boolean) => void
+  // onExpandedChange gets called immediately after the menu is triggered,
+  // unlike onOpenChange which gets called after the menu has been fully rendered/closed.
+  onExpandedChange?: (isOpen: boolean) => void
 }
 export type MenuTriggerProps = {
   children: React.ReactElement


### PR DESCRIPTION
Added new prop called `onExpandedChange` which does the callback earlier than onOpenChange, which fixes issues with for example rotating an arrow depending on the expanded state. See videos below for example

It uses the same API design as `onOpenChange`.

Using new prop `onExpandedChange`

https://user-images.githubusercontent.com/6342534/197208109-72d2e365-e8a1-46d3-9396-92b79741ed8c.mp4

Using `onOpenChange`

https://user-images.githubusercontent.com/6342534/197208490-be14fd0c-95ad-459d-bd5f-60ff07a9c21c.mp4

