### PR TITLE
fix: enable custom styling of arrow components

### DIFF
--- a/docs/docs/components/context-menu.md
+++ b/docs/docs/components/context-menu.md
@@ -112,10 +112,11 @@ See the Radix UI [docs for `ContextMenu.Content`](https://www.radix-ui.com/docs/
 
 Wraps the trigger for your menu. The content will be anchored to the trigger.
 
-| Prop     | Required | Default     | Platforms        |
-| -------- | -------- | ----------- | ---------------- |
-| `style`  |          |             | `web`            |
-| `action` |          | `longPress` | `ios`, `android` |
+| Prop      | Required | Default     | Platforms               |
+| --------- | -------- | ----------- | ----------------------- |
+| `style`   |          |             | `web`                   |
+| `action`  |          | `longPress` | `ios`, `android`        |
+| `asChild` |          | `false`     | `web`, `ios`, `android` |
 
 The `action` can be `longPress` or `press`.
 
@@ -383,11 +384,22 @@ On iOS & Android, only one label is supported (unless it is inside a submenu). I
 
 Renders an arrow on web only. This helps point the content to the trigger. The `Arrow` must be rendered inside of `Content`.
 
-| Prop     | Required | Default | Platforms |
-| -------- | -------- | ------- | --------- |
-| `style`  |          |         | `web`     |
-| `height` |          |         | `web`     |
-| `width`  |          |         | `web`     |
+By default, Radix renders the arrow as an `<svg>` element. You can customize the SVG arrow color by passing a `fill` prop, `className`, or `style` object with a `fill` property.
+
+:::caution
+
+Because the arrow is an `<svg>` element, its `style` prop is not React Native compatible. Styling it with React Native libraries may not work as expected. If you would like to render a custom styled `<View>`, use the `asChild` prop instead of wrapping this component.
+
+:::
+
+| Prop        | Required | Default | Platforms |
+| ----------- | -------- | ------- | --------- |
+| `width`     |          | 10      | `web`     |
+| `height`    |          | 5       | `web`     |
+| `fill`      |          |         | `web`     |
+| `style`     |          |         | `web`     |
+| `className` |          |         | `web`     |
+| `asChild`   |          | `false` | `web`     |
 
 ### Separator
 

--- a/docs/docs/components/dropdown-menu.md
+++ b/docs/docs/components/dropdown-menu.md
@@ -109,10 +109,11 @@ See the Radix UI [docs for `DropdownMenu.Content`](https://www.radix-ui.com/docs
 
 Wraps the trigger for your menu. The content will be anchored to the trigger.
 
-| Prop     | Required | Default | Platforms        |
-| -------- | -------- | ------- | ---------------- |
-| `style`  |          |         | `web`            |
-| `action` |          | `press` | `ios`, `android` |
+| Prop      | Required | Default | Platforms               |
+| --------- | -------- | ------- | ----------------------- |
+| `style`   |          |         | `web`                   |
+| `action`  |          | `press` | `ios`, `android`        |
+| `asChild` |          | `false` | `web`, `ios`, `android` |
 
 The `action` can be `longPress` or `press`.
 
@@ -348,11 +349,22 @@ On iOS & Android, only one label is supported (unless it is inside a submenu). I
 
 Renders an arrow on web only. This helps point the content to the trigger. The `Arrow` must be rendered inside of `Content`.
 
-| Prop     | Required | Default | Platforms |
-| -------- | -------- | ------- | --------- |
-| `style`  |          |         | `web`     |
-| `height` |          |         | `web`     |
-| `width`  |          |         | `web`     |
+By default, Radix renders the arrow as an `<svg>` element. You can customize the SVG arrow color by passing a `fill` prop, `className`, or `style` object with a `fill` property.
+
+:::caution
+
+Because the arrow is an `<svg>` element, its `style` prop is not React Native compatible. Styling it with React Native libraries may not work as expected. If you would like to render a custom styled `<View>`, use the `asChild` prop instead of wrapping this component.
+
+:::
+
+| Prop        | Required | Default | Platforms |
+| ----------- | -------- | ------- | --------- |
+| `width`     |          | 10      | `web`     |
+| `height`    |          | 5       | `web`     |
+| `fill`      |          |         | `web`     |
+| `style`     |          |         | `web`     |
+| `className` |          |         | `web`     |
+| `asChild`   |          | `false` | `web`     |
 
 ### Separator
 

--- a/examples/expo/src/App.tsx
+++ b/examples/expo/src/App.tsx
@@ -211,7 +211,17 @@ const DropdownMenuLabel = DropdownMenu.create(
   'ItemImage'
 )
 
+const DropdownMenuArrow = DropdownMenu.create(
+  (props: ComponentProps<typeof DropdownMenu.Arrow>) => (
+    <DropdownMenu.Arrow {...props} style={{ fill: '#fff' }} />
+  ),
+  'Arrow'
+)
+
 const DropdownMenuExample = () => {
+  const [arrowEnabled, setArrowEnabled] = useState<'on' | 'off' | 'mixed'>(
+    'off'
+  )
   const [bookmarked, setBookmarked] = useState<'on' | 'off' | 'mixed'>('on')
   return (
     <DropdownMenu.Root>
@@ -281,6 +291,19 @@ const DropdownMenuExample = () => {
             resizeMode="contain"
           />
         </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          style={dropdownStyles.item}
+          value={arrowEnabled}
+          onValueChange={setArrowEnabled}
+          key="fourth"
+        >
+          <DropdownMenuItemIndicator>
+            <Ionicons name="checkmark" size={19} />
+          </DropdownMenuItemIndicator>
+          <DropdownMenuItemTitle>
+            {arrowEnabled === 'on' ? 'Arrow enabled' : 'Arrow disabled'}
+          </DropdownMenuItemTitle>
+        </DropdownMenuCheckboxItem>
 
         <DropdownMenu.Sub>
           <DropdownMenuSubTrigger style={dropdownStyles.item} key="nested">
@@ -329,6 +352,7 @@ const DropdownMenuExample = () => {
             </DropdownMenu.SubContent>
           </DropdownMenu.Sub>
         </DropdownMenu.Group>
+        {arrowEnabled === 'on' ? <DropdownMenuArrow /> : null}
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   )
@@ -443,8 +467,8 @@ const ContextMenuExample = () => {
 export default function App() {
   return (
     <View style={styles.container}>
+      <DropdownMenuExample />
       <View style={{ height: 30 }} />
-      {/* <DropdownMenuExample /> */}
       <ContextMenuExample />
     </View>
   )

--- a/packages/zeego/src/context-menu/context-menu.web.tsx
+++ b/packages/zeego/src/context-menu/context-menu.web.tsx
@@ -224,12 +224,8 @@ const ItemIcon = create(({ children, style }: MenuItemIconProps) => {
 
 const Preview = create(() => <></>, 'Preview')
 
-const Arrow = create(({ style, children, width, height }: MenuArrowProps) => {
-  return (
-    <ContextMenu.Arrow width={width} height={height}>
-      <View style={[{ height, width }, style]}>{children}</View>
-    </ContextMenu.Arrow>
-  )
+const Arrow = create(({ children, ...restProps }: MenuArrowProps) => {
+  return <ContextMenu.Arrow {...restProps}>{children}</ContextMenu.Arrow>
 }, 'Arrow')
 
 const Sub = create(({ children }: MenuSubProps) => {

--- a/packages/zeego/src/dropdown-menu/dropdown-menu.web.tsx
+++ b/packages/zeego/src/dropdown-menu/dropdown-menu.web.tsx
@@ -230,12 +230,8 @@ const ItemIcon = ({ children, style }: MenuItemIconProps) => {
 
 ItemIcon.displayName = MenuDisplayName.ItemIcon
 
-const Arrow = create(({ style, children, width, height }: MenuArrowProps) => {
-  return (
-    <DropdownMenu.Arrow height={height} width={width}>
-      <View style={[{ height, width }, style]}>{children}</View>
-    </DropdownMenu.Arrow>
-  )
+const Arrow = create(({ children, ...restProps }: MenuArrowProps) => {
+  return <DropdownMenu.Arrow {...restProps}>{children}</DropdownMenu.Arrow>
 }, 'Arrow')
 
 const Sub = create<MenuSubProps>(({ children }) => {

--- a/packages/zeego/src/menu/types.ts
+++ b/packages/zeego/src/menu/types.ts
@@ -1,4 +1,4 @@
-import type { Text, View, ImageProps, ViewProps } from 'react-native'
+import type { Text, View, ImageProps } from 'react-native'
 import type { MenuContentProps as RadixContentProps } from '@radix-ui/react-dropdown-menu'
 import type {
   ContextMenuView,
@@ -9,9 +9,9 @@ import type {
   ImageOptions,
   ImageSystemSymbolConfiguration,
 } from 'react-native-ios-context-menu/lib/typescript/types/ImageItemConfig'
+import type { ComponentProps, SVGAttributes } from 'react'
 
 import type { SFSymbol } from 'sf-symbols-typescript'
-import type { ComponentProps } from 'react'
 
 type ViewStyle = React.ComponentProps<typeof View>['style']
 type TextStyle = React.ComponentProps<typeof Text>['style']
@@ -150,12 +150,14 @@ export type MenuItemImageProps = MenuItemCommonProps & {
   }
 } & Pick<ImageProps, 'accessibilityLabel'>
 
+type SVGProps = SVGAttributes<SVGSVGElement>
+
 export type MenuArrowProps = {
   height?: number
   width?: number
-  style?: ViewProps['style']
   children?: React.ReactNode
-}
+  asChild?: boolean
+} & Pick<SVGProps, 'fill' | 'style' | 'className'>
 
 export type MenuSubTriggerProps = Omit<
   MenuItemProps,


### PR DESCRIPTION
Fixes #67 

This PR updates the `Arrow` component of both menu types to more closely map to the props supported by Radix's Arrow.

By default, Radix's `Arrow` renders a custom `<svg>` arrow element and accepts all props that an `<svg>` does. The expected means of styling it are either to pass in a `fill` attribute, a `className`, a `style` object with `fill`, or to use its `asChild` prop and render a custom component.

Currently, Zeego's `Arrow` renders a custom `<View>` inside Radix's arrow, which gets the `style` prop passed to it. This child is never rendered by Radix, so these styles are never used.

---

To remedy this, I've updated the Arrow components to accept all of the attributes mentioned above (`fill`, `className`, `style`)

I also changed the way props are passed to the Arrow to use object spreading - this way, if someone finds another reason to pass additional HTML attributes to the arrow `<svg>` there's an easy escape hatch already in place - they just need to bypass Typescript.

There is also one one small "breaking" change: 

Because the `<svg>` isn't being rendered by a `<View>` and because it needs to be able to support the `fill` property in order to be useful, the `style` prop on the Arrow is no longer a `ViewStyle`, but a normal `CSSProperties` object. I stuck a warning in the docs calling this out. If anyone was passing StyleSheet styles there before, those styles weren't being rendered anyway :sweat_smile: 

---

While I was in there updating docs, I also updated the `Trigger` prop tables to include the `asChild` prop, which I noticed was missing. Happy to remove that change it if was intentionally undocumented.