### PR TITLE
docs: update cli to use npx expo and plugins config typo fix

### DIFF
--- a/docs/docs/start.md
+++ b/docs/docs/start.md
@@ -31,7 +31,7 @@ yarn add @react-native-menu/menu
 If you're using an Expo Development Client, there are some additional steps:
 
 ```yarn
-expo install expo-build-properites
+npx expo install expo-build-properites
 ```
 
 Next, add this to your app config's plugins array:
@@ -39,20 +39,21 @@ Next, add this to your app config's plugins array:
 ```js
 export default {
   plugins: [
-    "expo-build-properties",
+    [
+      "expo-build-properties",
       {
-       android: {
-        // these values were tested with Expo SDK 48
-        compileSdkVersion: 33,
-        targetSdkVersion: 33,
-        minSdkVersion: 23,
-        buildToolsVersion: '33.0.0',
-        kotlinVersion: '1.6.20',
+        android: {
+          // these values were tested with Expo SDK 48
+          compileSdkVersion: 33,
+          targetSdkVersion: 33,
+          minSdkVersion: 23,
+          buildToolsVersion: "33.0.0",
+          kotlinVersion: "1.6.20",
+        },
       },
-    }
-  ]
-}
-
+    ],
+  ],
+};
 ```
 
 If you know your way around these, you may be able to adjust them. But if you get an error related to `react-native-menu` when building, please reference these properties.
@@ -78,7 +79,7 @@ To install your dev client on your iPhone, make sure it's plugged in to your Mac
 After the development client build is complete, you can run your app in dev mode:
 
 ```bash
-expo start --dev-client
+npx expo start --dev-client
 ```
 
 If your app is on the App Store, you'll need to deploy a new build too:

--- a/docs/docs/start.md
+++ b/docs/docs/start.md
@@ -31,7 +31,7 @@ yarn add @react-native-menu/menu
 If you're using an Expo Development Client, there are some additional steps:
 
 ```yarn
-npx expo install expo-build-properites
+npx expo install expo-build-properties
 ```
 
 Next, add this to your app config's plugins array:


### PR DESCRIPTION
While using zeego in a new project, noticed a few issues:

* Using `expo` cli command is now deprecated, and `expo-build-properties` didn't install in my case. Updated to use `npx expo` instead
* The plugins config schema for expo requires you to provide the config for a plugin (in this case `expo-build-properties`) as a tuple array to the plugins array.
* Fixed typo in expo package name `expo-build-properites` to `expo-build-properties`

Hope this is useful!