### PR TITLE
Fix: missing checkmark icon on Android's CheckboxItem

### DIFF
--- a/packages/zeego/src/menu/create-android-menu/index.android.tsx
+++ b/packages/zeego/src/menu/create-android-menu/index.android.tsx
@@ -365,10 +365,23 @@ If you want to use a custom component as your <Content />, you can use the creat
                   ? 'off'
                   : menuState
 
+              const hasItemIndicator =
+                pickChildren(child.props.children, ItemIndicator)
+                  .targetChildren?.[0] !== undefined
+
+              let image = icon
+
+              if (hasItemIndicator && !icon) {
+                image =
+                  currentState === 'on'
+                    ? 'checkbox_on_background'
+                    : 'checkbox_off_background'
+              }
+
               const finalItem: MenuItem = {
                 id: key,
                 title,
-                image: icon,
+                image,
                 attributes: menuAttributes,
                 subtitle,
                 state: currentState,


### PR DESCRIPTION
Closes #45

This PR ensures the CheckboxItem component renders a checkmark on Android when the `<ItemIndicator />` component is available. The implementation follows the composability patterns of Zeego:
1. Allow users to override the icon by passing a `<ItemIcon />` component.
2. Allow users to hide the checkmark icon by not passing the `<ItemIndicator />` component. See _Notes_, I believe this should also be the iOS behavior given what's written in the docs, but this might be a breaking change.
3. Renders the native checkmark icon when the `<ItemIcon />` is available.

### Code example
See the _Screenshots_ section for the before/after of running this code:

```tsx
<DropdownMenu.Root>
  <DropdownMenu.Trigger>
    <Button onPress={noop} variant="secondary">
      Default
    </Button>
  </DropdownMenu.Trigger>
  <DropdownMenu.Content>
    <DropdownMenu.Item key="1">
      <DropdownMenu.ItemTitle>Item + ItemIcon</DropdownMenu.ItemTitle>
      <DropdownMenu.ItemIcon androidIconName="btn_star" />
    </DropdownMenu.Item>

    {/* Expected: no checkmark icon */}
    <DropdownMenu.CheckboxItem key="2" value="off">
      <DropdownMenu.ItemTitle>CheckboxItem, off</DropdownMenu.ItemTitle>
    </DropdownMenu.CheckboxItem>

    {/* Expected: no checkmark icon */}
    <DropdownMenu.CheckboxItem key="3" value="on">
      <DropdownMenu.ItemTitle>CheckboxItem, on</DropdownMenu.ItemTitle>
    </DropdownMenu.CheckboxItem>

    {/* Expected: checkmark off icon */}
    <DropdownMenu.CheckboxItem key="4" value="off">
      <DropdownMenu.ItemTitle>
        CheckboxItem + ItemIndicator, off
      </DropdownMenu.ItemTitle>
      <DropdownMenu.ItemIndicator />
    </DropdownMenu.CheckboxItem>

    {/* Expected: checkmark on icon */}
    <DropdownMenu.CheckboxItem key="5" value="on">
      <DropdownMenu.ItemTitle>
        CheckboxItem + ItemIndicator, on
      </DropdownMenu.ItemTitle>
      <DropdownMenu.ItemIndicator />
    </DropdownMenu.CheckboxItem>

    {/* Expected: custom icon */}
    <DropdownMenu.CheckboxItem key="5" value="on">
      <DropdownMenu.ItemTitle>
        CheckboxItem + ItemIcon
      </DropdownMenu.ItemTitle>
      <DropdownMenu.ItemIcon androidIconName="btn_star" />
      <DropdownMenu.ItemIndicator />
    </DropdownMenu.CheckboxItem>
  </DropdownMenu.Content>
</DropdownMenu.Root>
```

### Screenshots




|         | Before (Bug)                                                                                                                                                   | After (Fixed)                                                                                                                                                    |
|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| Android | <img width="560" alt="CleanShot 2024-03-17 at 19 01 29@2x" src="https://github.com/nandorojo/zeego/assets/8047841/922c425e-cce1-4339-81e8-4709018de5b8"> | <img width="560" alt="CleanShot 2024-03-17 at 19 06 58@2x" src="https://github.com/nandorojo/zeego/assets/8047841/583cf569-f474-4883-ba72-a9f839618716"> |
|         |                                                                                                                                                          |                                                                                                                                                          |



### Notes

My understanding from the ItemIndicator [docs](https://zeego.dev/components/dropdown-menu#itemindicator) is that Android and iOS Menus should only show the native checkmarks if the `<ItemIndicator />` component is rendered. However, this isn't the runtime behavior yet:
- iOS shows the native checkmark, irrespectively of whether ItemIndicator is rendered or not.
- Android (before my PR) didn't show any icons, with or without ItemIndicator