### PR TITLE
Fix: Bug where root style was not passed into root android component

### DIFF
--- a/packages/zeego/src/menu/create-android-menu/index.android.tsx
+++ b/packages/zeego/src/menu/create-android-menu/index.android.tsx
@@ -449,6 +449,7 @@ If you want to use a custom component as your <Content />, you can use the creat
     return (
       <MenuView
         title={menuTitle}
+        style={props.style}
         onPressAction={({ nativeEvent }) => {
           callbacks[nativeEvent.event]?.()
         }}


### PR DESCRIPTION
Thanks for the great library! Here's a quick fix for a small bug I found on Android. 

When passing in a `style` to the `Zeego.Root` component on Android, the property is ignored, unlike web and iOS. 