### PR TITLE
doc: update documentation for Expo SDK 52 peer dependencies

### DIFF
--- a/docs/docs/start.md
+++ b/docs/docs/start.md
@@ -22,6 +22,13 @@ yarn add zeego
 yarn add react-native-ios-context-menu react-native-ios-utilities
 ```
 
+For users on Expo SDK 52 with the New Architecture enabled, install the following versions of the peer dependencies to ensure compatibility:
+
+```sh
+yarn add react-native-ios-context-menu@3.0.0-23 react-native-ios-utilities@5.0.0-58
+```
+
+
 #### Android
 
 ```sh
@@ -121,3 +128,5 @@ You need to add `zeego` to your `next-transpile-modules` in `next.config.js`.
 ### Vanilla React Native
 
 Run `pod install` in your `ios` folder.
+
+


### PR DESCRIPTION
This PR updates the documentation to include the correct peer dependencies for Expo SDK 52 with New Architecture support.

You can view the discussions that led to identifying the correct dependencies here:
[Zeego Issue #108](https://github.com/nandorojo/zeego/issues/108)
[React Native iOS Utilities Issue #13 Comment](https://github.com/dominicstop/react-native-ios-utilities/issues/13#issuecomment-2568303771)