### PR TITLE
Fix typo in start.md

### DIFF
--- a/docs/docs/start.md
+++ b/docs/docs/start.md
@@ -42,13 +42,13 @@ npm i \
 #### yarn
 
 ```sh
-yarn add @react-native-menu@1.2.2
+yarn add @react-native-menu/menu@1.2.2
 ```
 
 #### npm
 
 ```sh
-npm i @react-native-menu@1.2.2 --legacy-peer-deps
+npm i @react-native-menu/menu@1.2.2 --legacy-peer-deps
 ```
 
 ### Compatibility Table


### PR DESCRIPTION
`@react-native-menu` is not a valid library on npm

I assume you meant `@react-native-menu/menu`

![CleanShot 2025-03-05 at 18 31 28@2x](https://github.com/user-attachments/assets/8ea430fb-3803-4766-b94b-c271eed86dfb)
