### PR TITLE
Added support for custom icons on iOS and isAnchoredToRight for android

### DIFF
--- a/packages/zeego/src/menu/create-android-menu/index.android.tsx
+++ b/packages/zeego/src/menu/create-android-menu/index.android.tsx
@@ -256,7 +256,7 @@ If you want to use a custom component as your <Content />, you can use the creat
         } else {
           console.error(
             `[zeego] Invalid <${Menu}.Item key="${key}" /> Missing valid title. Make sure you do one of the following:
-  
+
   1. pass a string as the child of <${Menu}.ItemTitle />, nested directly inside of <${Menu}.Item />.
   2. OR, use the textValue prop on <${Menu}.Item textValue="Some value" />`
           )
@@ -462,6 +462,7 @@ If you want to use a custom component as your <Content />, you can use the creat
         onOpenMenu={() => {
           props.onOpenChange?.(true)
         }}
+        isAnchoredToRight={triggerItem?.props.isAnchoredToRight ?? false}
         // @ts-ignore
         onCloseMenu={() => {
           props.onOpenChange?.(false)

--- a/packages/zeego/src/menu/create-ios-menu/index.ios.tsx
+++ b/packages/zeego/src/menu/create-ios-menu/index.ios.tsx
@@ -278,14 +278,26 @@ If you want to use a custom component as your <Content />, you can use the creat
         ) {
           const iconConfiguration = iconChildren?.[0]?.props.ios
 
-          icon = {
-            type: 'IMAGE_SYSTEM',
-            imageValue: {
-              ...iconConfiguration,
-              systemName:
-                iconConfiguration?.name ?? iconChildren[0].props.iosIconName,
-            } as ImageSystemConfig,
-          }
+          icon =
+            iconConfiguration && iconConfiguration.type === 'IMAGE_ASSET'
+              ? {
+                  type: 'IMAGE_ASSET',
+                  imageValue: iconConfiguration.name,
+                  imageOptions: {
+                    tint: iconConfiguration.tint,
+                    renderingMode: iconConfiguration.renderingMode,
+                    cornerRadius: iconConfiguration.cornerRadius,
+                  },
+                }
+              : {
+                  type: 'IMAGE_SYSTEM',
+                  imageValue: {
+                    ...iconConfiguration,
+                    systemName:
+                      iconConfiguration?.name ??
+                      iconChildren[0].props.iosIconName,
+                  } as ImageSystemConfig,
+                }
         } else {
           const imageChild = pickChildren<MenuItemImageProps>(
             child.props.children,

--- a/packages/zeego/src/menu/types.ts
+++ b/packages/zeego/src/menu/types.ts
@@ -7,7 +7,11 @@ import type {
   ContextMenuButton,
   ImageOptions,
 } from 'react-native-ios-context-menu'
-import { ImageSystemSymbolConfiguration } from 'react-native-ios-utilities'
+import {
+  DynamicColor,
+  ImageRenderingModes,
+  ImageSystemSymbolConfiguration,
+} from 'react-native-ios-utilities'
 import type { SFSymbol } from 'sf-symbols-typescript'
 
 type ViewStyle = React.CSSProperties
@@ -53,6 +57,10 @@ export type MenuTriggerProps = RadixDropdownMenu.DropdownMenuTriggerProps & {
    * Only applies for `ios` and `android`.
    */
   action?: 'press' | 'longPress'
+  /**
+   * Only applies for `android`.
+   */
+  isAnchoredToRight?: boolean
 }
 
 export type MenuContentProps = React.ComponentPropsWithoutRef<
@@ -112,16 +120,27 @@ export type MenuItemIconProps = {
    */
   iosIconName?: string
   /**
-   * Icon configuration to be used on iOS. You can pass a SF Symbol icon using the `name` prop.
-   * Additionally, you can configure the SF Symbol's features like weight, scale, color etc. by passing
-   * the corresponding props. Note that some of those features require iOS 15+. For the full list of options,
-   * refer to the ImageSystemSymbolConfiguration type in react-native-ios-context-menu
+   * Icon configuration to be used on iOS. You can pass either:
+   * 1. A SF Symbol icon with optional configuration properties (default type is 'IMAGE_SYSTEM')
+   * 2. An asset image using 'type: IMAGE_ASSET' with optional styling properties
+   *
+   * Note that some SF Symbol features require iOS 15+. For the full list of options,
+   * refer to the ImageSystemSymbolConfiguration type in react-native-ios-utilities.
    *
    * @platform ios
    */
-  ios?: ImageSystemSymbolConfiguration & {
-    name: SFSymbol
-  }
+  ios?:
+    | ({
+        type?: 'IMAGE_SYSTEM'
+        name: SFSymbol
+      } & ImageSystemSymbolConfiguration)
+    | {
+        type: 'IMAGE_ASSET'
+        name: string
+        tint?: string | DynamicColor | undefined
+        renderingMode?: ImageRenderingModes
+        cornerRadius?: number
+      }
   /**
    * The name of an android-only resource drawable. For a full list, see https://developer.android.com/reference/android/R.drawable.html.
    *
@@ -231,5 +250,5 @@ export type ContextMenuPreviewProps = {
   onPress?: React.ComponentProps<typeof ContextMenuView>['onPressMenuPreview']
 } & Not<
   NonNullable<React.ComponentProps<typeof ContextMenuView>['previewConfig']>,
-  'targetViewNode' | 'previewSize' | 'previewType'
+  'previewSize' | 'previewType'
 >

--- a/packages/zeego/src/menu/types.ts
+++ b/packages/zeego/src/menu/types.ts
@@ -250,5 +250,5 @@ export type ContextMenuPreviewProps = {
   onPress?: React.ComponentProps<typeof ContextMenuView>['onPressMenuPreview']
 } & Not<
   NonNullable<React.ComponentProps<typeof ContextMenuView>['previewConfig']>,
-  'previewSize' | 'previewType'
+  'targetViewNode' | 'previewSize' | 'previewType'
 >


### PR DESCRIPTION
I've also been really keen on using zeego for my mobile app. But as the android side was so hideous I usually opted to just creating my own custom menu instead. But recently I saw that one can actually customize the android to make it look somewhat decent. I still needed custom icon support and allowing the android menu to be anchored to the right. To achieve the customization as I use expo I just have some plugins to copy the assets into the native folders and convert the svgs to the native icon formats. Not sure if my implementation on the iOS side is the cleanest, but it works. Same goes for android in order to actually set the prop one needs tell typescript to ignore the error, as its actually just using radix types for the Trigger as far as I can tell.

Short example in use:
```
<DropdownMenu.Root>
  {/* @ts-expect-error */}
  <DropdownMenu.Trigger isAnchoredToRight={true}>
    <TouchableOpacity>
      <View className="w-16 h-16 bg-primary rounded-full items-center justify-center">
        <Icon name="Plus" className="text-white dark:text-white size-8" />
      </View>
    </TouchableOpacity>
  </DropdownMenu.Trigger>
  <DropdownMenu.Content>
    <DropdownMenu.Label />
    <DropdownMenu.Item key="1">
      <DropdownMenu.ItemTitle>Scan Face</DropdownMenu.ItemTitle>
      <DropdownMenu.ItemIcon
        androidIconName="scan_face"
        ios={{
          type: "IMAGE_ASSET",
          name: "scan-face",
          // tint: {
          //   dark: "red",
          //   light: "blue",
          // },
          // renderingMode: "automatic",
        }}
      />
    </DropdownMenu.Item>
    <DropdownMenu.Item key="2">
      <DropdownMenu.ItemTitle>Scan QR Code</DropdownMenu.ItemTitle>
      <DropdownMenu.ItemIcon
        androidIconName="qr_code"
        ios={{
          type: "IMAGE_ASSET",
          name: "qr-code",
        }}
      />
    </DropdownMenu.Item>
    <DropdownMenu.Item key="3">
      <DropdownMenu.ItemTitle>Scan NFC Tag</DropdownMenu.ItemTitle>
      <DropdownMenu.ItemIcon
        androidIconName="nfc"
        ios={{
          type: "IMAGE_ASSET",
          name: "nfc",
        }}
      />
    </DropdownMenu.Item>
  </DropdownMenu.Content>
</DropdownMenu.Root>
 ```

<p float="left">
  <img src="https://github.com/user-attachments/assets/327c3971-5ff1-44fa-9944-e969496b2f45" width="400" />
  <img src="https://github.com/user-attachments/assets/8540af31-1d22-4075-af50-35e363829229" width="400" />
</p>
<img width="253" alt="image" src="https://github.com/user-attachments/assets/444f4153-3027-40ea-8c8d-6eaf5f865480" />
