### PR TITLE
docs: fix wrong onSelect prop availability

### DIFF
--- a/docs/docs/components/context-menu.md
+++ b/docs/docs/components/context-menu.md
@@ -566,7 +566,7 @@ An item that opens a submenu. Must be rendered inside `ContextMenu.Sub`.
 | `destructive` |          |         | `web` , `ios`, `android` |
 | `hidden`      |          |         | `ios`, `android`         |
 | `style`       |          |         | `web`                    |
-| `onSelect`    |          |         | `web`                    |
+| `onSelect`    |          |         | `web`, `android`, `ios`  |
 | `textValue`   |          |         | `web`                    |
 | `onFocus`     |          |         | `web`                    |
 | `onBlur`      |          |         | `web`                    |

--- a/docs/docs/components/dropdown-menu.md
+++ b/docs/docs/components/dropdown-menu.md
@@ -149,7 +149,7 @@ The `key` prop is **required**. The same `key` must not be used more than once i
 | `destructive` |          |         | `web`, `ios`, `android` |
 | `hidden`      |          |         | `ios`, `android`        |
 | `style`       |          |         | `web`                   |
-| `onSelect`    |          |         | `web`                   |
+| `onSelect`    |          |         | `web`, `android`, `ios` |
 | `textValue`   |          |         | `web`                   |
 | `onFocus`     |          |         | `web`                   |
 | `onBlur`      |          |         | `web`                   |
@@ -515,7 +515,7 @@ An item that opens a submenu. Must be rendered inside `DropdownMenu.Sub`.
 | `destructive` |          |         | `web` , `ios`, `android` |
 | `hidden`      |          |         | `ios`, `android`         |
 | `style`       |          |         | `web`                    |
-| `onSelect`    |          |         | `web`                    |
+| `onSelect`    |          |         | `web`, `android`, `ios` |
 | `textValue`   |          |         | `web`                    |
 | `onFocus`     |          |         | `web`                    |
 | `onBlur`      |          |         | `web`                    |


### PR DESCRIPTION
The docs are wrongly stating that `onSelect` is only available on web.